### PR TITLE
Set chatbot text direction to right-to-left

### DIFF
--- a/src/components/ChatBot.jsx
+++ b/src/components/ChatBot.jsx
@@ -7,7 +7,7 @@ function ChatBot({ setShowChat }) {
   };
 
   return (
-    <div className="h-full flex flex-col relative" dir="rtl">
+    <div className="h-full flex flex-col relative" dir="rtl" lang="he">
       {/* כפתור סגירה קטן בפינה */}
       <button
         onClick={handleClose}
@@ -19,7 +19,7 @@ function ChatBot({ setShowChat }) {
       
       <div className="flex-1 overflow-hidden relative">
         <iframe
-          src="https://chatrace.com/webchat/?p=1249354&ref=1753054769905"
+          src="https://chatrace.com/webchat/?p=1249354&ref=1753054769905&lang=he&locale=he&direction=rtl&rtl=1"
           className="w-full h-full border-none"
           title="צ'אטבוט"
           style={{

--- a/src/index.css
+++ b/src/index.css
@@ -125,6 +125,7 @@ button, a {
   overflow: hidden;
   animation: slideUp 0.3s ease-out;
   direction: rtl;
+  text-align: right;
 }
 
 @keyframes slideUp {


### PR DESCRIPTION
Configure chatbot to display text from right-to-left (RTL) to support Hebrew language.

---
<a href="https://cursor.com/background-agent?bcId=bc-9da52160-4523-42cc-a4fa-1ac8da6c3365">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9da52160-4523-42cc-a4fa-1ac8da6c3365">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

